### PR TITLE
0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ eikobot/core/lib/
 !eikobot/core/lib/__init__.py
 !eikobot/core/lib/std/
 
+.eikobot_cache
+
 # Test files
 /test.eiko
 /test.py

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@
 - Add a plugin `type` that returns the typing of an object as a string
 - Made all the tests windows compatible
 - If host verification fails due to missing keys, we allow the user to add those key
+- Add `for` loops that loop over iterables (currently just lists and dicts)
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
 - Made TaskID accessible through `HandlerContext`
 - Added Task cache (This is a directory unique to the current Task/Handler and can be used to save files)
 - Fixed several bugs in the type system
+- Add a 🤖 to some logs
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@
 - Fixed a bug where a hanging comma in a constructor arg list would cause a syntax error
 - Made TaskID accessible through `HandlerContext`
 - Added Task cache (This is a directory unique to the current Task/Handler and can be used to save files)
+- Fixed several bugs in the type system
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@
 - Added Task cache (This is a directory unique to the current Task/Handler and can be used to save files)
 - Fixed several bugs in the type system
 - Add a 🤖 to some logs
+- Fixed a bug in the package manager that occurred when installing an already installed package
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.6.0
+
+- Much better support for windows hosts!
+- Added `HostModel.scp_to` and `HostModel.scp_from` to copy files with SCP
+
 ## 0.5.1 HOTFIX
 
 This patch fixes a bug in the package manager that wrongly reports a package was not installed

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@
 
 - Much better support for windows hosts!
 - Added `HostModel.scp_to` and `HostModel.scp_from` to copy files with SCP
+- Fixed a bug where `.` wasn't parsed properly in the inheritance declaration
+- Fixed a bug where promises were not properly inherited
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
 - Made all the tests windows compatible
 - If host verification fails due to missing keys, we allow the user to add those key
 - Add `for` loops that loop over iterables (currently just lists and dicts)
+- Impement `dict.get` function, that canr retrieve a value with a default value
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
 - Fixed a bug where promises were not properly inherited
 - Implemented `...`, a statement that allows for inhertiting without new properties being added
 - Allow inheritance to only overwrite the constructor, with no aditional properties
+- Fixed a bug where lists and dicts as default arguments caused a compilation issue
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,8 +14,10 @@
 - Made TaskID accessible through `HandlerContext`
 - Added Task cache (This is a directory unique to the current Task/Handler and can be used to save files)
 - Fixed several bugs in the type system
-- Add a 🤖 to some logs
+- Add a 🤖 to some of the logs
 - Fixed a bug in the package manager that occurred when installing an already installed package
+- Add a plugin `type` that returns the typing of an object as a string
+- Made all the tests cross platform (windows) compatible
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,8 @@
 - Fixed a bug where lists and dicts as default arguments caused a compilation issue
 - Fixed a bug in the comparison operations where `None` would not equal itself
 - Fixed a bug where a hanging comma in a constructor arg list would cause a syntax error
+- Made TaskID accessible through `HandlerContext`
+- Added Task cache (This is a directory unique to the current Task/Handler and can be used to save files)
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@
 - Added `HostModel.scp_to` and `HostModel.scp_from` to copy files with SCP
 - Fixed a bug where `.` wasn't parsed properly in the inheritance declaration
 - Fixed a bug where promises were not properly inherited
+- Implemented `...`, a statement that allows for inhertiting without new properties being added
+- Allow inheritance to only overwrite the constructor, with no aditional properties
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 - Implemented `...`, a statement that allows for inhertiting without new properties being added
 - Allow inheritance to only overwrite the constructor, with no aditional properties
 - Fixed a bug where lists and dicts as default arguments caused a compilation issue
+- Fixed a bug in the comparison operations where `None` would not equal itself
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
 - Allow inheritance to only overwrite the constructor, with no aditional properties
 - Fixed a bug where lists and dicts as default arguments caused a compilation issue
 - Fixed a bug in the comparison operations where `None` would not equal itself
+- Fixed a bug where a hanging comma in a constructor arg list would cause a syntax error
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,7 +17,8 @@
 - Add a 🤖 to some of the logs
 - Fixed a bug in the package manager that occurred when installing an already installed package
 - Add a plugin `type` that returns the typing of an object as a string
-- Made all the tests cross platform (windows) compatible
+- Made all the tests windows compatible
+- If host verification fails due to missing keys, we allow the user to add those key
 
 ## 0.5.1 HOTFIX
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,8 +6,8 @@
 - Added `HostModel.scp_to` and `HostModel.scp_from` to copy files with SCP
 - Fixed a bug where `.` wasn't parsed properly in the inheritance declaration
 - Fixed a bug where promises were not properly inherited
-- Implemented `...`, a statement that allows for inhertiting without new properties being added
-- Allow inheritance to only overwrite the constructor, with no aditional properties
+- Implemented `...`, a statement that allows for inheriting without new properties being added
+- Allow inheritance to only overwrite the constructor, with no additional properties
 - Fixed a bug where lists and dicts as default arguments caused a compilation issue
 - Fixed a bug in the comparison operations where `None` would not equal itself
 - Fixed a bug where a hanging comma in a constructor arg list would cause a syntax error
@@ -20,7 +20,7 @@
 - Made all the tests windows compatible
 - If host verification fails due to missing keys, we allow the user to add those key
 - Add `for` loops that loop over iterables (currently just lists and dicts)
-- Impement `dict.get` function, that canr retrieve a value with a default value
+- Implement `dict.get` function, that can retrieve a value with a default value
 
 ## 0.5.1 HOTFIX
 

--- a/README.md
+++ b/README.md
@@ -51,32 +51,3 @@ Or by activating the venv first:
 . eikobot-venv/bin/activate
 eikobot
 ```
-
-## Linters, type checkers, testing, etc
-
-Currently this project uses:
-
-- `mypy` for advanced type checking
-- `isort` to auto format the imports
-- `black` to auto format code
-- `flake8` to do basic linting (and pointing out where isort and black would make changes)
-- `pylint` for advanced linting and code smell detection
-- `bandit` to scan for security issues
-
-Note that the `flake8-isort` and `flake8-black` plugins are used,
-and Flake8 will emit `isort` and `black` issues but not auto format them,
-these tools will still need to be ran afterwards to fix any errors.  
-The `Flake8-pylint` and `Flake8-mypy` plugins are not used as they are in broken state.  
-
-For vscode, adding the following settings to your config is recommended:
-
-```json
-{
-    "python.linting.flake8Enabled": true,
-    "python.linting.mypyEnabled": true,
-    "python.linting.pylintEnabled": true,
-    "python.testing.pytestEnabled": true,
-    "python.testing.pytestArgs": [],
-    "editor.insertSpaces": true,
-}
-```

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -8,3 +8,70 @@ Docs for the development of eikobot itself.
 python -m build
 twine upload --repository pypi dist/*
 ```
+
+## Linters, type checkers, testing, etc
+
+Currently this project uses:
+
+- `mypy` for advanced type checking
+- `isort` to auto format the imports
+- `black` to auto format code
+- `flake8` to do basic linting (and pointing out where isort and black would make changes)
+- `pylint` for advanced linting and code smell detection
+- `bandit` to scan for security issues
+
+Note that the `flake8-isort` and `flake8-black` plugins are used,
+and Flake8 will emit `isort` and `black` issues but not auto format them,
+these tools will still need to be ran afterwards to fix any errors.  
+The `Flake8-pylint` and `Flake8-mypy` plugins are not used as they are in broken state.  
+
+For vscode, adding the following settings to your config is recommended:
+
+```json
+{
+    "python.linting.flake8Enabled": true,
+    "python.linting.mypyEnabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": [],
+    "editor.insertSpaces": true,
+}
+```
+
+## Debugging
+
+I often use a `test.eiko` and `test.py` file in the root of the project
+for trying new ideas.  
+These are ignored by git.  
+
+Add the following to your vscode config to `launch.json`, to be able to debug them:
+
+```json
+ {
+    "name": "Compile test.eiko",
+    "type": "python",
+    "request": "launch",
+    "module": "eikobot",
+    "justMyCode": true,
+    "args": [
+        "--debug",
+        "compile",
+        "-f",
+        "test.eiko",
+        "--output-model"
+    ]
+},
+{
+    "name": "Deploy test.eiko",
+    "type": "python",
+    "request": "launch",
+    "module": "eikobot",
+    "justMyCode": true,
+    "args": [
+        "--debug",
+        "deploy",
+        "-f",
+        "test.eiko"
+    ]
+},
+```

--- a/docs/language_overview.md
+++ b/docs/language_overview.md
@@ -1,10 +1,11 @@
 # Eiko language overview
 
 This overview assumes the user hase some knowledge of programming.  
-The language itself is designed to mimic Python and
-Python is required for writing `plugins` and `handlers`.  
+The language itself is designed to mimic Python as closely as makes sense.  
+Furthermore knowledge of Python is required for writing `plugins` and `handlers`,
+as those are written in Python.  
 
-Furthmore, knowledge of Pythons typing system is highly recommended.  
+Furthmore, knowledge of Pythons typing system is highly recommende it.  
 
 ## The compile command
 
@@ -425,6 +426,24 @@ Further testing will also show our custom resource `Service` does not accept bad
 ```Python
 s = Service(-1)
 ```
+
+## For loops
+
+Using the `for` keyword we can loop over iterables, such as lists and dicts.  
+This works much like it does in Python:
+
+```Python
+haha = "haha"
+test_list: list[Union[str, int]] = []
+
+for obj in ["hello", haha, 12]:
+    test_list.append(obj)
+
+for obj in {"key_1": "test", 1: 1}:
+    test_list.append(obj)
+```
+
+
 
 ## importing and modules
 

--- a/docs/language_overview.md
+++ b/docs/language_overview.md
@@ -1245,14 +1245,14 @@ resource Car:
 ```
 
 While a promise can be passed around to other objects and even stored in a variable,
-keep in mind that it more restricted in its uses than normal values.  
-For example, due to the nature of a promise only be resolved during deployment,
-rather then during compilation, this means it can not be used in binary operations.  
+keep in mind that it is more restricted in its uses than normal values.  
+For example, due to the nature of promises, they can only be resolved during deployment,
+rather then during compilation.
 Nor can it be passed to plugins, unless the plugin is expressly written to support this.  
 
 Another potential pitfall is that promises can not be used for the index of the
 resource that is going to resolve them.  
-However, they _can_ be used to generate the index of toher resources.  
+However, they _can_ be used to generate the index of other resources.  
 When doing this, rather than using the eventual value to generate the index
 (a value that might change in the future for example), it will return a string
 based on its property name and the name of the resource it belong to.  
@@ -1354,5 +1354,5 @@ platform = some_host.os_platform.resolve(str)
 ```
 
 So resolve makes sure we get a value of the type we expect and that the value actually already exists.  
-While Eikobot takes promises in to account when calculating task dependencies,
-this is an extra safety measure.  
+Eikobot takes promises in to account when calculating task dependencies,
+as an extra safety measure.  

--- a/docs/language_overview.md
+++ b/docs/language_overview.md
@@ -222,6 +222,11 @@ Note the typing, expressed as `dict[key_type, value_type]`.
 When not typed, it takes all it's initial keys and values,
 and expresses the value as a union of those types.  
 
+Retrieving values can be done, either by using the `d[key]` notation,
+or but using the `get` method.  
+The upside of the get method is that it allows for a default value,
+in case the key is not in the dictionary.  
+
 ### Resources
 
 Finaly we have the `resource`.  

--- a/docs/quickstarts.md
+++ b/docs/quickstarts.md
@@ -14,7 +14,7 @@ Unless mentioned otherwise, setting up a new project for each quickstart is reco
 ## Create a new project
 
 Create a new directory `eikobot-quickstarts`.  
-Inside this directory, set up a python3.10+ venv, and activate it:  
+Inside this directory, set up a python3.11+ venv, and activate it:  
 
 ```sh
 python3.10 -m venv .env

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,11 +35,11 @@ Features and bug fixes:
 - [x] link handlers to resources
 - [x] custom constructors
 - [x] add relative imports
-- [ ] add `isinstance`
+- [x] add `type` plugin. Works the same as python `type`
 - [x] inheritance for `resource`
 - [x] add protected strings (strings that will not be printed)
 - [ ] add `Tuple` data type and automatic unpacking of tuples
-- [ ] add `for` keyword, to loop over lists, dicts and tuples
+- [x] add `for` keyword, to loop over lists, dicts (and tuples)
 - [ ] expand type system to take module in to account when resolving types
 - [x] add `enum`
 - [x] add `promise` (A piece of data that will be filled in during the deploy step)
@@ -48,7 +48,7 @@ Code cleanup:
 
 - [ ] Implement an `expects` function for parser, raise if token is not correct type
 - [x] Implement a `to_py` function on eiko objects, instead of using a conversion table
-- [ ] Overhaul the way comparissons are done. (Should be a function of object a, not a matrix function)
+- [ ] Overhaul the way comparissons are done. (Should be a function of object a, not a matrix lookup function)
 
 ### STD
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@ Writing the basic tutorials and quickstarts.
 
 ### Compiler
 
-Features and bug fixes:
+Features and bug fixes:  
 
 - [x] basic lexer
 - [x] basic expression parser
@@ -48,6 +48,7 @@ Code cleanup:
 
 - [ ] Implement an `expects` function for parser, raise if token is not correct type
 - [x] Implement a `to_py` function on eiko objects, instead of using a conversion table
+- [ ] Overhaul the way comparissons are done. (Should be a function of object a, not a matrix function)
 
 ### STD
 
@@ -71,12 +72,12 @@ Code cleanup:
 - [x] add deployer that takes tasks and executes them
 - [x] add linked pydantic classes
 - [x] add logging to HandlerContext
-- [ ] add dry run to `deploy`
+- [x] add dry run to `deploy`
 
-## Phase 2: Packages
+## Package Manager
 
-Phase 2 is all about allowing reuse of code and such.  
-Adding a package manager and a way to build, install and uninstall packages easily
+This is all about allowing reuse of code and such.  
+Adding a package manager and a way to build, install and uninstall packages easily  
 
 - [x] build packages
 - [x] install packages using a path to the `tar.gz` file

--- a/eikobot/__main__.py
+++ b/eikobot/__main__.py
@@ -109,7 +109,7 @@ def _compile(
     pc_time_taken_formatted = str(datetime.timedelta(seconds=pc_time_taken))
     time_taken_formatted = str(datetime.timedelta(seconds=time_taken))
     logger.info(
-        f"Compiled in {time_taken_formatted} "
+        f"🤖 Compiled in {time_taken_formatted} "
         f"(Process time: {pc_time_taken_formatted})"
     )
 
@@ -162,7 +162,7 @@ def deploy(
         else:
             time_taken = time.time() - start
             time_taken_formatted = str(datetime.timedelta(seconds=time_taken))
-            logger.info(f"Deployed in {time_taken_formatted}")
+            logger.info(f"🤖 Deployed in {time_taken_formatted}")
 
 
 @cli.group()

--- a/eikobot/__main__.py
+++ b/eikobot/__main__.py
@@ -109,7 +109,7 @@ def _compile(
     pc_time_taken_formatted = str(datetime.timedelta(seconds=pc_time_taken))
     time_taken_formatted = str(datetime.timedelta(seconds=time_taken))
     logger.info(
-        f"🤖 Compiled in {time_taken_formatted} "
+        f"Compiled in {time_taken_formatted} 🤖 "
         f"(Process time: {pc_time_taken_formatted})"
     )
 
@@ -162,7 +162,7 @@ def deploy(
         else:
             time_taken = time.time() - start
             time_taken_formatted = str(datetime.timedelta(seconds=time_taken))
-            logger.info(f"🤖 Deployed in {time_taken_formatted}")
+            logger.info(f"Deployed in {time_taken_formatted} 🤖")
 
 
 @cli.group()

--- a/eikobot/core/__init__.py
+++ b/eikobot/core/__init__.py
@@ -1,3 +1,44 @@
 """
 The nuts and bolts of Eikobot.
 """
+
+
+def human_readable(number: int) -> str:
+    """
+    Turns a large integer representing bytes
+    in to a human readable string.
+    """
+    number = number // 8
+    for unit in ["", "K", "M", "G", "T"]:
+        if number < 10240:
+            return f"{number}{unit}B"
+        number = number // 1024
+    return f"{number}PB"
+
+
+def machine_readable(number: str) -> int:
+    """
+    Turns a human readable number of bytes in to an integer.
+    """
+    if number.isdigit():
+        return int(number)
+
+    if number.endswith("B"):
+        return int(number[:-1])
+
+    if number.endswith("KB"):
+        return int(number[:-2]) * 1024
+
+    if number.endswith("MB"):
+        return int(number[:-2]) * 1024**2
+
+    if number.endswith("GB"):
+        return int(number[:-2]) * 1024**3
+
+    if number.endswith("TB"):
+        return int(number[:-2]) * 1024**4
+
+    if number.endswith("PB"):
+        return int(number[:-2]) * 1024**5
+
+    raise ValueError(f"Cannot convert value of '{number}' to an integer.")

--- a/eikobot/core/compiler/_parser.py
+++ b/eikobot/core/compiler/_parser.py
@@ -2012,7 +2012,7 @@ class Parser:
 
         if self._current.type != TokenType.COLON:
             raise EikoParserError(
-                f"Unexpected token {self._current.content}.",
+                f"Unexpected token {self._current.content}. Expected a ':'.",
                 token=self._current,
             )
         self._advance()
@@ -2031,6 +2031,12 @@ class Parser:
                 "expected indented code block.",
                 token=self._current,
             )
+
+        if self._next.type == TokenType.TRIPLE_DOT:
+            self._advance()
+            self._advance()
+            return rd_ast
+
         indent = self._current.content
         constructor: Optional[ConstructorExprAST] = None
         while True:
@@ -2051,11 +2057,11 @@ class Parser:
                 pass
             else:
                 raise EikoSyntaxError(
-                    f"Unexpected token in resource definition '{rd_ast.name}'",
-                    index=rd_ast.token.index,
+                    f"Unexpected token '{self._current.content}' in resource definition '{rd_ast.name}'",
+                    index=self._current.index,
                 )
 
-        if not rd_ast.properties:
+        if not rd_ast.properties and rd_ast.super_expr is None:
             raise EikoSyntaxError(
                 "A resource must have atleast 1 property. (Besides promises.)",
                 index=rd_ast.token.index,

--- a/eikobot/core/compiler/_parser.py
+++ b/eikobot/core/compiler/_parser.py
@@ -1689,7 +1689,9 @@ class ForExprAst(ExprAST):
 
         for obj in compiled_iterable.iterate(self.iterable_expr.token):
             sub_context = context.get_subcontext(f"{context.name}-for")
-            self.loop_var_expr.assign(obj, sub_context, context, self.loop_var_expr.token)
+            self.loop_var_expr.assign(
+                obj, sub_context, context, self.loop_var_expr.token
+            )
             for line in self.body:
                 line.compile(sub_context)
 
@@ -2574,16 +2576,14 @@ class Parser:
 
         if self._current.type != TokenType.IDENTIFIER:
             raise EikoParserError(
-                f"Unexpected token {self._next.content}, "
-                "expected an identifier.",
+                f"Unexpected token {self._next.content}, " "expected an identifier.",
                 token=self._next,
             )
 
         loop_var_expr = self._parse_identifier()
         if self._current.type != TokenType.IN:
             raise EikoParserError(
-                f"Unexpected token {self._next.content}, "
-                "expected an 'in' token.",
+                f"Unexpected token {self._next.content}, " "expected an 'in' token.",
                 token=self._next,
             )
         self._advance()
@@ -2591,8 +2591,7 @@ class Parser:
 
         if self._current.type != TokenType.COLON:
             raise EikoParserError(
-                f"Unexpected token {self._next.content}, "
-                "expected a ':'.",
+                f"Unexpected token {self._next.content}, " "expected a ':'.",
                 token=self._next,
             )
         self._advance()

--- a/eikobot/core/compiler/_parser.py
+++ b/eikobot/core/compiler/_parser.py
@@ -2181,6 +2181,12 @@ class Parser:
                     "Expected a ',' or a ')'.", index=self._current.index
                 )
             self._advance(skip_indentation=True)
+            if (
+                self._current.type == TokenType.RIGHT_PAREN
+                and self._next.type == TokenType.COLON
+            ):
+                self._advance()
+                break
             args.append(self._parse_consructor_arg())
             if self._current.type == TokenType.INDENT:
                 self._advance(skip_indentation=True)

--- a/eikobot/core/compiler/_token.py
+++ b/eikobot/core/compiler/_token.py
@@ -38,6 +38,8 @@ class TokenType(Enum):
     COLON = auto()
     COMMA = auto()
     DOT = auto()
+    DOUBLE_DOT = auto()
+    TRIPLE_DOT = auto()
     AT_SIGN = auto()
 
     DOUBLE_COLON = auto()

--- a/eikobot/core/compiler/_token.py
+++ b/eikobot/core/compiler/_token.py
@@ -26,6 +26,8 @@ class TokenType(Enum):
     DEF = auto()
     PROMISE = auto()
     ENUM = auto()
+    FOR = auto()
+    IN = auto()
 
     IDENTIFIER = auto()
 

--- a/eikobot/core/compiler/definitions/_resource.py
+++ b/eikobot/core/compiler/definitions/_resource.py
@@ -5,10 +5,10 @@ Resource is the base building block of the eiko language model.
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union
 
-from ...handlers import Handler
 from .base_types import EikoBaseType, EikoPromise, EikoResource, EikoType
 
 if TYPE_CHECKING:
+    from ...handlers import Handler
     from .._parser import ResourceDefinitionAST, TypeExprAST
     from .._token import Token
     from .base_model import EikoBaseModel
@@ -69,7 +69,7 @@ class EikoResourceDefinition(EikoBaseType):
         self.properties: PropertiesDict = properties
         self.index_def = [list(properties.keys())[0]]
         self.promises: list[EikoPromiseDefinition] = promises
-        self.handler: Optional[type[Handler]] = None
+        self.handler: Optional[type["Handler"]] = None
         self.linked_basemodel: Optional[type["EikoBaseModel"]] = None
 
     def printable(self, indent: str = "") -> str:

--- a/eikobot/core/compiler/definitions/_resource.py
+++ b/eikobot/core/compiler/definitions/_resource.py
@@ -9,7 +9,7 @@ from ...handlers import Handler
 from .base_types import EikoBaseType, EikoPromise, EikoResource, EikoType
 
 if TYPE_CHECKING:
-    from .._parser import ResourceDefinitionAST
+    from .._parser import ResourceDefinitionAST, TypeExprAST
     from .._token import Token
     from .base_model import EikoBaseModel
     from .function import ConstructorDefinition
@@ -25,6 +25,7 @@ class ResourceProperty:
     name: str
     type: EikoType
     default_value: Optional[EikoBaseType] = None
+    type_expr: "TypeExprAST | None" = None
 
 
 @dataclass

--- a/eikobot/core/compiler/definitions/base_types.py
+++ b/eikobot/core/compiler/definitions/base_types.py
@@ -122,6 +122,9 @@ EikoObjectType = EikoType("Object")
 
 def type_list_to_type(types: list[EikoType]) -> EikoType:
     """Turns a list of Eiko types in to a single usable type."""
+    if len(types) == 0:
+        return EikoType("")
+
     if len(types) == 1:
         _type = types[0]
     else:

--- a/eikobot/core/compiler/definitions/base_types.py
+++ b/eikobot/core/compiler/definitions/base_types.py
@@ -895,9 +895,9 @@ class EikoListType(EikoType):
 
     def type_check(self, expected_type: "EikoType") -> bool:
         if isinstance(expected_type, EikoListType):
-            return expected_type.element_type.type_check(self.element_type)
+            return self.element_type.type_check(expected_type.element_type)
 
-        return False
+        return super().type_check(expected_type)
 
 
 class EikoList(EikoBaseType):
@@ -1002,7 +1002,7 @@ class EikoDictType(EikoType):
             ) and self.value_type.type_check(expected_type.value_type):
                 return True
 
-        return False
+        return super().type_check(expected_type)
 
 
 EikoIndexTypes = Union[

--- a/eikobot/core/compiler/definitions/base_types.py
+++ b/eikobot/core/compiler/definitions/base_types.py
@@ -210,6 +210,12 @@ class EikoBaseType:
     def to_py(self) -> Union[PyTypes, "EikoPromise"]:
         raise NotImplementedError
 
+    def iterate(self, token: Token) -> Iterator["EikoBaseType"]:
+        raise EikoCompilationError(
+            f"Object of type '{self.type}' is not iterable.",
+            token=token,
+        )
+
 
 EikoNoneType = EikoType("None")
 
@@ -986,6 +992,10 @@ class EikoList(EikoBaseType):
     def to_py(self) -> list[Union[PyTypes, "EikoPromise"]]:
         return [element.to_py() for element in self.elements]
 
+    def iterate(self, _: Token) -> Iterator["EikoBaseType"]:
+        for element in self.elements:
+            yield element
+
 
 class EikoDictType(EikoType):
     """Represents an Eiko Union type, which combines 2 or more types."""
@@ -1170,6 +1180,10 @@ class EikoDict(EikoBaseType):
             f"Object of type '{key.type.name}' can not be for keys in dictionairies.",
             token=key_token,
         )
+
+    def iterate(self, _: Token) -> Iterator["EikoBaseType"]:
+        for element in self.elements:
+            yield to_eiko(element)
 
 
 # Move to another file

--- a/eikobot/core/compiler/definitions/base_types.py
+++ b/eikobot/core/compiler/definitions/base_types.py
@@ -1173,7 +1173,7 @@ class EikoDict(EikoBaseType):
 
 
 # Move to another file
-def to_eiko_type(cls: Optional[Type]) -> Type[EikoBaseType]:
+def to_eiko_type(cls: Optional[Type]) -> Type[EikoBaseType] | Type[EikoType]:
     """
     Takes a python type and returns it's eikobot compatible type.
     If said type exists.
@@ -1181,7 +1181,7 @@ def to_eiko_type(cls: Optional[Type]) -> Type[EikoBaseType]:
     if cls is None:
         return EikoNone
 
-    if issubclass(cls, EikoBaseType):
+    if issubclass(cls, EikoBaseType) or issubclass(cls, EikoType):
         return cls
 
     if cls == bool:
@@ -1254,7 +1254,7 @@ def to_eiko(value: Any) -> EikoBaseType:
     if isinstance(value, EikoBaseType):
         return value
 
-    if isinstance(value, BaseModel):
+    if isinstance(value, BaseModel) and hasattr(value, "raw_resource"):
         return value.raw_resource  # type: ignore
 
     if value is None:

--- a/eikobot/core/compiler/definitions/context.py
+++ b/eikobot/core/compiler/definitions/context.py
@@ -200,7 +200,10 @@ class CompilerContext:
         """Set a value. Throws an error if it's already set."""
         prev_value = self.shallow_get(name)
         if isinstance(prev_value, EikoUnset):
-            if prev_value.type.inverse_type_check(value.type):
+            if (
+                prev_value.type.inverse_type_check(value.type)
+                and prev_value.type.name != value.type.name
+            ):
                 constr = self.get(prev_value.type.name)
                 if isinstance(constr, EikoTypeDef):
                     if isinstance(value, EikoBaseType):

--- a/eikobot/core/compiler/definitions/context.py
+++ b/eikobot/core/compiler/definitions/context.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Optional, Type, Union
 from ... import logger
 from ...errors import EikoCompilationError, EikoInternalError
 from ...handlers import Handler
-from ...plugin import eiko_type
+from ...plugin import eiko_type, human_readable, machine_readable
 from .._token import Token
 from ..decorator import index_decorator
 from ..importlib import _load_plugin, import_python_code
@@ -52,6 +52,8 @@ _builtins: dict[str, _StorableTypes] = {
     "dict": EikoDictType,
     "index": index_decorator,
     "type": _load_plugin("", "type", eiko_type),
+    "human_readable": _load_plugin("", "human_readable", human_readable),
+    "machine_readable": _load_plugin("", "machine_readable", machine_readable),
 }
 
 

--- a/eikobot/core/compiler/definitions/context.py
+++ b/eikobot/core/compiler/definitions/context.py
@@ -147,8 +147,8 @@ class CompilerContext:
                 return_str += value.printable(extra_indent)
             elif isinstance(value, EikoBaseType):
                 extra_extra_indent = extra_indent + "    "
-                return_str += f"{extra_indent}var '{key}':\n"
-                return_str += extra_extra_indent + value.printable(extra_extra_indent)
+                return_str += f"{extra_indent}var '{key}': "
+                return_str += value.printable(extra_extra_indent)
                 return_str += "\n"
             else:
                 return_str += f"{extra_indent}{key}: {value}\n"

--- a/eikobot/core/compiler/definitions/context.py
+++ b/eikobot/core/compiler/definitions/context.py
@@ -9,9 +9,10 @@ from typing import TYPE_CHECKING, Optional, Type, Union
 from ... import logger
 from ...errors import EikoCompilationError, EikoInternalError
 from ...handlers import Handler
+from ...plugin import eiko_type
 from .._token import Token
 from ..decorator import index_decorator
-from ..importlib import import_python_code
+from ..importlib import _load_plugin, import_python_code
 from ._resource import EikoResourceDefinition
 from .base_model import EikoBaseModel
 from .base_types import (
@@ -50,6 +51,7 @@ _builtins: dict[str, _StorableTypes] = {
     "list": EikoListType,
     "dict": EikoDictType,
     "index": index_decorator,
+    "type": _load_plugin("", "type", eiko_type),
 }
 
 

--- a/eikobot/core/compiler/definitions/function.py
+++ b/eikobot/core/compiler/definitions/function.py
@@ -2,8 +2,20 @@
 While real functions don't exist in the eiko language,
 constructors and plugins do, and they need some kind of representation.
 """
+import inspect
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional, Type, Union
+from pathlib import Path
+from types import UnionType
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    List,
+    Optional,
+    Type,
+    Union,
+    get_args,
+    get_origin,
+)
 
 from ...errors import EikoCompilationError, EikoInternalError, EikoPluginError
 from ...plugin import EikoPluginException, EikoPluginTyping
@@ -303,7 +315,7 @@ class PluginDefinition(EikoBaseType):
 
     def _handle_arg(
         self, arg: "ExprAST", context: "CompilerContext", required_arg: PluginArg
-    ) -> Union[EikoBaseType, bool, float, int, str]:
+    ) -> "StorableTypes | PyTypes":
         compiled_arg = arg.compile(context)
         if compiled_arg is None:
             raise EikoCompilationError(
@@ -311,25 +323,72 @@ class PluginDefinition(EikoBaseType):
                 f"but expression did not result in a suitable value.",
                 token=arg.token,
             )
-        if issubclass(required_arg.py_type, EikoBaseType):
-            converted_arg: Union["StorableTypes", PyTypes] = compiled_arg
-        else:
+
+        converted_arg: "StorableTypes | PyTypes"
+        if required_arg.py_type in [None, bool, float, int, str, dict, list, Path]:
             if isinstance(compiled_arg, EikoBaseType):
-                converted_arg = compiled_arg.to_py()
+                try:
+                    converted_arg = compiled_arg.to_py()
+                except NotImplementedError:
+                    converted_arg = compiled_arg
             else:
+                converted_arg = compiled_arg
+
+            if not isinstance(converted_arg, required_arg.py_type):
                 raise EikoCompilationError(
-                    "Failed to convert to python type when passing to plugin.",
+                    f"Plugin '{self.module}.{self.identifier}' arg '{required_arg.name}' expects an argument "
+                    f"of type '{required_arg.py_type.__name__}', but instead got '{compiled_arg.type}'.",
                     token=arg.token,
                 )
 
-        if not isinstance(converted_arg, required_arg.py_type):
-            raise EikoCompilationError(
-                f"Plugin '{self.module}.{self.identifier}' arg '{required_arg.name}' expects an argument "
-                f"of type '{required_arg.py_type.__name__}', but instead got '{compiled_arg.type}'.",
-                token=arg.token,
+            return converted_arg
+
+        converted_arg = compiled_arg
+
+        if self._type_check(converted_arg, required_arg.py_type):
+            return converted_arg
+
+        raise EikoCompilationError(
+            f"Plugin '{self.module}.{self.identifier}' arg '{required_arg.name}' expects an argument "
+            f"of type '{required_arg.py_type}', but instead got '{compiled_arg.type}'.",
+            token=arg.token,
+        )
+
+    def _type_check(self, arg: "StorableTypes | PyTypes", expected: Type) -> bool:
+        try:
+            return isinstance(arg, expected)
+        except TypeError:
+            pass
+
+        origin = get_origin(expected)
+        if origin in (Union, UnionType):
+            for arg_type in get_args(expected):
+                if self._type_check(arg, arg_type):
+                    return True
+            return False
+
+        if origin is (list, List):
+            # if not isinstance(arg, list):
+            #     return False
+            #  args = get_args(expected)
+            raise EikoInternalError(
+                "Something went horribly wrong during a python runtime type check."
             )
 
-        return converted_arg  # type: ignore
+        if origin in (dict, Dict):
+            raise EikoInternalError(
+                "Something went horribly wrong during a python runtime type check."
+            )
+
+        if origin in (type, Type):
+            for arg_type in get_args(expected):
+                if inspect.isclass(arg) and issubclass(arg, arg_type):
+                    return True
+            return False
+
+        raise EikoInternalError(
+            "Something went horribly wrong during a python runtime type check."
+        )
 
     def truthiness(self) -> bool:
         raise NotImplementedError

--- a/eikobot/core/compiler/definitions/function.py
+++ b/eikobot/core/compiler/definitions/function.py
@@ -173,9 +173,9 @@ class ConstructorDefinition(EikoBaseType):
         keyword_args: dict[str, PassedArg],
     ) -> None:
         for passed_arg, arg in zip(positional_args, list(self.args.values())[1:]):
-            if not passed_arg.value.type_check(arg.type):
+            if not passed_arg.value.type.type_check(arg.type):
                 # Try to coerce the type
-                if arg.type.inverse_type_check(passed_arg.value.type):
+                if passed_arg.value.type.inverse_type_check(arg.type):
                     if arg.type.typedef is None:
                         raise EikoInternalError(
                             "Failed to coerce type.",
@@ -207,7 +207,7 @@ class ConstructorDefinition(EikoBaseType):
                     token=passed_arg.token,
                 )
 
-            if not passed_arg.value.type_check(kw_arg.type):
+            if not passed_arg.value.type.type_check(kw_arg.type):
                 if kw_arg.type.inverse_type_check(passed_arg.value.type):
                     if kw_arg.type.typedef is not None:
                         passed_arg.value = kw_arg.type.typedef.execute(

--- a/eikobot/core/compiler/definitions/function.py
+++ b/eikobot/core/compiler/definitions/function.py
@@ -71,7 +71,7 @@ class ConstructorDefinition(EikoBaseType):
         if self.parent.promises and self.parent.handler is None:
             raise EikoCompilationError(
                 f"Resource Definition '{self.parent.name}' has promises, "
-                "but no handler",
+                "but no handler.",
                 token=self.parent.expr.token,
             )
 

--- a/eikobot/core/compiler/definitions/typedef.py
+++ b/eikobot/core/compiler/definitions/typedef.py
@@ -52,7 +52,7 @@ class EikoTypeDef(EikoBaseType):
         """
         Cast a value to a type and make sure it fits the given condition expression.
         """
-        if arg.type_check(self.type):
+        if arg.type.type_check(self.type):
             raise EikoCompilationError(
                 f"Type '{self.name}' requires '{self.type.name}' but was passed '{arg.type.name}'.",
                 token=arg_token,

--- a/eikobot/core/compiler/importlib.py
+++ b/eikobot/core/compiler/importlib.py
@@ -6,8 +6,8 @@ import importlib.util
 from dataclasses import dataclass
 from inspect import getfullargspec, getmembers, isclass, isfunction
 from pathlib import Path
-from types import FunctionType, ModuleType
-from typing import TYPE_CHECKING, Optional
+from types import ModuleType
+from typing import TYPE_CHECKING, Callable, Optional
 
 from .. import logger
 from ..errors import EikoCompilationError
@@ -209,7 +209,7 @@ def load_python_code(module_name: str, file_path: Path) -> ModuleType:
     raise EikoCompilationError(f"Failed to import python module {module_name} ")
 
 
-def _load_plugin(module: str, name: str, function: FunctionType) -> PluginDefinition:
+def _load_plugin(module: str, name: str, function: Callable) -> PluginDefinition:
     fullargspec = getfullargspec(function)
     annotations = fullargspec.annotations
     return_type = annotations.get("return", "")

--- a/eikobot/core/compiler/lexer.py
+++ b/eikobot/core/compiler/lexer.py
@@ -36,7 +36,6 @@ SPECIAL_CHARS = {
     "{": TokenType.LEFT_BRACE,
     "}": TokenType.RIGHT_BRACE,
     ",": TokenType.COMMA,
-    ".": TokenType.DOT,
     "@": TokenType.AT_SIGN,
 }
 
@@ -231,6 +230,16 @@ class Lexer:
             special_char = self._current
             self._next()
             return Token(SPECIAL_CHARS[special_char], special_char, index)
+
+        if self._current == ".":
+            self._next()
+            if self._current == ".":
+                self._next()
+                if self._current == ".":
+                    self._next()
+                    return Token(TokenType.TRIPLE_DOT, "...", index)
+                return Token(TokenType.DOUBLE_DOT, "..", index)
+            return Token(TokenType.DOT, ".", index)
 
         if self._current == "=":
             self._next()

--- a/eikobot/core/compiler/lexer.py
+++ b/eikobot/core/compiler/lexer.py
@@ -26,6 +26,8 @@ KEYWORDS = {
     "def": TokenType.DEF,
     "promise": TokenType.PROMISE,
     "enum": TokenType.ENUM,
+    "for": TokenType.FOR,
+    "in": TokenType.IN,
 }
 
 SPECIAL_CHARS = {

--- a/eikobot/core/compiler/lexer.py
+++ b/eikobot/core/compiler/lexer.py
@@ -195,9 +195,13 @@ class Lexer:
                 )
 
         self._next()
-        escaped_string = bytes(_string, encoding="utf-8").decode(
-            encoding="unicode_escape"
-        )
+        try:
+            escaped_string = bytes(_string, encoding="utf-8").decode(
+                encoding="unicode_escape"
+            )
+        except UnicodeDecodeError as e:
+            raise EikoSyntaxError(str(e), index=index) from e
+
         return Token(TokenType.STRING, escaped_string, index)
 
     def _scan_raw_string(self, index: Index) -> Token:
@@ -213,10 +217,7 @@ class Lexer:
                 )
 
         self._next()
-        raw_string = bytes(_string, encoding="utf-8").decode(
-            encoding="raw_unicode_escape"
-        )
-        return Token(TokenType.STRING, raw_string, index)
+        return Token(TokenType.STRING, _string, index)
 
     def _scan_f_string(self, index: Index) -> Token:
         string_token = self._scan_string()

--- a/eikobot/core/compiler/ops.py
+++ b/eikobot/core/compiler/ops.py
@@ -277,6 +277,9 @@ def _str_compare(a: EikoStr, b: EikoStr, op: ComparisonOP) -> EikoBool:
 def _eq_compare(
     a: EikoBaseType, b: EikoBaseType, op: ComparisonOP, b_token: Token
 ) -> EikoBool:
+    if a is b:
+        return EikoBool(True)
+
     if isinstance(a, (EikoInt, EikoFloat)) and isinstance(b, (EikoInt, EikoFloat)):
         return EikoBool(a.value == b.value)
 

--- a/eikobot/core/exporter.py
+++ b/eikobot/core/exporter.py
@@ -199,9 +199,10 @@ class Exporter:
             handler = resource.class_ref.handler()
             self.total_tasks += 1
 
+        _id = resource.index()
         task = Task(
-            resource.index(),
-            HandlerContext(resource),
+            _id,
+            HandlerContext(resource, _id),
             handler,
         )
 

--- a/eikobot/core/handlers.py
+++ b/eikobot/core/handlers.py
@@ -30,9 +30,19 @@ class HandlerContext:
         self.promises = self.raw_resource.promises
         self.name = self.raw_resource.index()
         self.extras: dict[str, Any] = {}
-        self.task_cache = CACHE_DIR / self.task_id
+        self.task_cache = CACHE_DIR / self.normalized_task_id()
 
         self.task_cache.mkdir(exist_ok=True)
+
+    def normalized_task_id(self) -> str:
+        """
+        Removes backslashes, forward slashes and : from the task_id
+        so it can be used for paths on both unix and windows.
+        """
+        _normalized = self.task_id.replace("\\", "-")
+        _normalized = _normalized.replace("/", "-")
+        _normalized = _normalized.replace(" ", "")
+        return _normalized.replace(":", ".")
 
     def add_change(self, key: str, value: Any) -> None:
         self.changes[key] = value

--- a/eikobot/core/handlers.py
+++ b/eikobot/core/handlers.py
@@ -24,6 +24,7 @@ class HandlerContext:
         self.failed = False
         self.promises = self.raw_resource.promises
         self.name = self.raw_resource.index()
+        self.extras: dict[str, Any] = {}
 
     def add_change(self, key: str, value: Any) -> None:
         self.changes[key] = value

--- a/eikobot/core/handlers.py
+++ b/eikobot/core/handlers.py
@@ -2,6 +2,7 @@
 Handlers are a way to describe to Eikobot how something should be deployed.
 """
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Union
 
 from . import logger
@@ -9,12 +10,16 @@ from .compiler.definitions.base_model import BaseModel
 from .compiler.definitions.base_types import EikoResource
 from .errors import EikoUnresolvedPromiseError
 
+CACHE_DIR = Path(".eikobot_cache")
+CACHE_DIR.mkdir(exist_ok=True)
+
 
 @dataclass
 class HandlerContext:
     """A HandlerContext keeps track of things required for a deployment."""
 
     raw_resource: EikoResource
+    task_id: str
 
     def __post_init__(self) -> None:
         self.resource: Union[dict, BaseModel]
@@ -25,6 +30,9 @@ class HandlerContext:
         self.promises = self.raw_resource.promises
         self.name = self.raw_resource.index()
         self.extras: dict[str, Any] = {}
+        self.task_cache = CACHE_DIR / self.task_id
+
+        self.task_cache.mkdir(exist_ok=True)
 
     def add_change(self, key: str, value: Any) -> None:
         self.changes[key] = value

--- a/eikobot/core/helpers.py
+++ b/eikobot/core/helpers.py
@@ -1,7 +1,10 @@
 # pylint: disable=unused-import
 """
-Eikobot base types and helper methods.
+Eikobot base types and helper methods,
+usefull for module developers.
+Imported from various places around the code.
 """
+from . import human_readable, machine_readable
 from .compiler.definitions.base_model import EikoBaseModel
 from .compiler.definitions.base_types import (
     EikoBaseType,

--- a/eikobot/core/lib/std/__init__.eiko
+++ b/eikobot/core/lib/std/__init__.eiko
@@ -22,15 +22,21 @@ resource Cmd:
     cmd: str
 
 
+enum Shell:
+    powershell
+    bash
+    sh
+
+
 @index(["host.host", "_hash"])
 resource Script:
     host: Host
     script: str
-    exec_shell: Optional[str]
+    exec_shell: Optional[Shell]
 
     _hash: str
 
-    def __init__(self, host: Host, script: str, exec_shell: Optional[str] = None):
+    def __init__(self, host: Host, script: str, exec_shell: Optional[Shell] = None):
         self.host = host
         self.script = script
         self.exec_shell = exec_shell

--- a/eikobot/core/lib/std/__init__.py
+++ b/eikobot/core/lib/std/__init__.py
@@ -154,7 +154,7 @@ class HostModel(EikoBaseModel):
         try:
             return await asyncssh.connect(self.host, **extra_args)
         except asyncssh.HostKeyNotVerifiable as e:
-            key_scan = await asyncio.subprocess.create_subprocess_shell(
+            key_scan = await asyncio.subprocess.create_subprocess_shell(  # pylint: disable=no-member
                 f"ssh {self.host} echo",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,

--- a/eikobot/core/lib/std/__init__.py
+++ b/eikobot/core/lib/std/__init__.py
@@ -344,6 +344,7 @@ class HostModel(EikoBaseModel):
             original_command = cmd
         ctx.debug("Execute: " + original_command)
 
+        cmd = cmd.replace('"', '\\"')
         if not cmd.startswith("powershell"):
             cmd_str = f'powershell "{cmd}"'
         else:

--- a/eikobot/core/lib/std/__init__.py
+++ b/eikobot/core/lib/std/__init__.py
@@ -232,8 +232,8 @@ class HostModel(EikoBaseModel):
     ) -> CmdResult:
         """Runs a script on the remote host."""
         if self.is_windows_host:
-            script_file_name = f"script-{ctx.task_id}.ps1"
-            with open(script_file_name, "w", encoding="utf-8") as f:
+            script_file_name = f"script-{ctx.normalized_task_id()}.ps1"
+            with open(ctx.task_cache / script_file_name, "w", encoding="utf-8") as f:
                 f.write(script)
 
             extra_args: dict[str, str] = {}
@@ -245,7 +245,7 @@ class HostModel(EikoBaseModel):
                     extra_args["password"] = self.password
 
             await asyncssh.scp(
-                script_file_name,
+                ctx.task_cache / script_file_name,
                 f"{self.host}:{script_file_name}",
                 **extra_args,  # type: ignore
             )
@@ -258,9 +258,8 @@ class HostModel(EikoBaseModel):
                 f"del {script_file_name}",
                 term_type="xterm-color",
             )
-            os.remove(script_file_name)
-
             return result
+
         if "sudo " in script:
             ssh_exec = self._execute_sudo
         else:

--- a/eikobot/core/lib/std/__init__.py
+++ b/eikobot/core/lib/std/__init__.py
@@ -164,7 +164,7 @@ class HostModel(EikoBaseModel):
             if key_scan.returncode != 0:
                 raise EikoDeployError(
                     f"Host verification failed \n{stderr.decode()}"
-                )
+                ) from e
             return await asyncssh.connect(self.host, **extra_args)
 
     def disconnect(self, ctx: HandlerContext) -> None:

--- a/eikobot/core/lib/std/__init__.py
+++ b/eikobot/core/lib/std/__init__.py
@@ -345,7 +345,7 @@ class HostModel(EikoBaseModel):
         ctx.debug("Execute: " + original_command)
 
         if not cmd.startswith("powershell"):
-            cmd_str = f"powershell {cmd}"
+            cmd_str = f'powershell "{cmd}"'
         else:
             cmd_str = cmd
 
@@ -379,6 +379,11 @@ class HostModel(EikoBaseModel):
         with open("returncode", encoding="utf-8") as f:
             returncode = int(f.read())
         os.remove("returncode")
+
+        await self._connection.run(
+            "del returncode",
+            term_type="xterm-color",
+        )
 
         await asyncssh.scp(
             f"{self.host}:output",

--- a/eikobot/core/lib/std/file.py
+++ b/eikobot/core/lib/std/file.py
@@ -107,46 +107,53 @@ class FileHandler(CRUDHandler):
             ctx.failed = True
             return
 
-        if ctx.resource.requires_sudo:
+        if ctx.resource.host.is_windows_host:
+            await self._create_win(ctx, ctx.resource)
+
+        else:
+            await self._create(ctx, ctx.resource)
+
+    async def _create(self, ctx: HandlerContext, resource: FileModel) -> None:
+        if resource.requires_sudo:
             sudo = "sudo "
         else:
             sudo = ""
 
-        result = await ctx.resource.host.execute(
-            f"{sudo}mkdir -p {ctx.resource.path.parent}", ctx
+        result = await resource.host.execute(
+            f"{sudo}mkdir -p {resource.path.parent}", ctx
         )
         if result.returncode != 0:
             ctx.failed = True
             return
 
-        result = await ctx.resource.host.execute(
-            f'echo -n "{ctx.resource.content}" | {sudo}tee {ctx.resource.path}',
+        result = await resource.host.execute(
+            f'echo -n "{resource.content}" | {sudo}tee {resource.path}',
             ctx,
         )
         if result.returncode != 0:
             ctx.failed = True
             return
 
-        result = await ctx.resource.host.execute(
-            f"{sudo}chmod {ctx.resource.mode} " f"{ctx.resource.path}",
+        result = await resource.host.execute(
+            f"{sudo}chmod {resource.mode} " f"{resource.path}",
             ctx,
         )
         if result.returncode != 0:
             ctx.failed = True
             return
 
-        if ctx.resource.owner is not None:
-            result = await ctx.resource.host.execute(
-                f"{sudo}chown {ctx.resource.owner} {ctx.resource.path}",
+        if resource.owner is not None:
+            result = await resource.host.execute(
+                f"{sudo}chown {resource.owner} {resource.path}",
                 ctx,
             )
             if result.returncode != 0:
                 ctx.failed = True
                 return
 
-        if ctx.resource.group is not None:
-            result = await ctx.resource.host.execute(
-                f"{sudo}chgrp {ctx.resource.group} {ctx.resource.path}",
+        if resource.group is not None:
+            result = await resource.host.execute(
+                f"{sudo}chgrp {resource.group} {resource.path}",
                 ctx,
             )
             if result.returncode != 0:
@@ -155,82 +162,110 @@ class FileHandler(CRUDHandler):
 
         ctx.deployed = True
 
+    async def _create_win(self, ctx: HandlerContext, resource: FileModel) -> None:
+        result = await resource.host.execute(f"mkdir {resource.path.parent}", ctx)
+        if result.returncode != 0:
+            ctx.failed = True
+            return
+
+        with open(ctx.task_cache / resource.path.name, "w", encoding="utf-8") as f:
+            f.write(resource.content)
+
+        await resource.host.scp_to(
+            str(ctx.task_cache / resource.path.name),
+            ctx,
+            str(resource.path),
+        )
+
+        ctx.deployed = True
+
     async def read(self, ctx: HandlerContext) -> None:
         if not isinstance(ctx.resource, FileModel):
             ctx.failed = True
             return
 
-        if ctx.resource.requires_sudo:
+        if ctx.resource.host.is_windows_host:
+            await self._read_win(ctx, ctx.resource)
+
+        else:
+            await self._read(ctx, ctx.resource)
+
+    async def _read(self, ctx: HandlerContext, resource: FileModel) -> None:
+        if resource.requires_sudo:
             sudo = "sudo "
         else:
             sudo = ""
 
-        cat_result = await ctx.resource.host.execute(
-            f"{sudo}cat {ctx.resource.path}", ctx
-        )
+        cat_result = await resource.host.execute(f"{sudo}cat {resource.path}", ctx)
         if cat_result.returncode == 0:
             ctx.deployed = True
-            if cat_result.output != ctx.resource.content:
+            if cat_result.output != resource.content:
                 ctx.add_change("content", cat_result.output)
 
-            ls_result = await ctx.resource.host.execute(
-                f"{sudo}ls -l {ctx.resource.path}", ctx
-            )
+            ls_result = await resource.host.execute(f"{sudo}ls -l {resource.path}", ctx)
             if ls_result.returncode == 0:
                 if isinstance(ls_result.output, str):
                     ls_parsed = ls_result.output.split(" ")
-                    if parse_rwx_mode(ls_parsed[0]) != ctx.resource.mode:
+                    if parse_rwx_mode(ls_parsed[0]) != resource.mode:
                         ctx.add_change("mode", parse_rwx_mode(ls_parsed[0]))
-                    if (
-                        ctx.resource.owner is not None
-                        and ls_parsed[2] != ctx.resource.owner
-                    ):
+                    if resource.owner is not None and ls_parsed[2] != resource.owner:
                         ctx.add_change("owner", ls_parsed[2])
-                    if (
-                        ctx.resource.group is not None
-                        and ls_parsed[3] != ctx.resource.group
-                    ):
+                    if resource.group is not None and ls_parsed[3] != resource.group:
                         ctx.add_change("group", ls_parsed[3])
                 else:
                     ctx.failed = True
+
+    async def _read_win(self, ctx: HandlerContext, resource: FileModel) -> None:
+        cat_result = await resource.host.execute(f"cat {resource.path}", ctx)
+        if cat_result.returncode == 0:
+            ctx.deployed = True
+            if cat_result.output != resource.content:
+                ctx.add_change("content", cat_result.output)
 
     async def update(self, ctx: HandlerContext) -> None:
         if not isinstance(ctx.resource, FileModel):
             ctx.failed = True
             return
 
-        if ctx.resource.requires_sudo:
+        if ctx.resource.host.is_windows_host:
+            await self._create_win(ctx, ctx.resource)
+
+        else:
+            await self._update(ctx, ctx.resource)
+
+    async def _update(self, ctx: HandlerContext, resource: FileModel) -> None:
+        if resource.requires_sudo:
             sudo = "sudo "
         else:
             sudo = ""
 
         if ctx.changes.get("content") is not None:
-            result = await ctx.resource.host.execute(
-                f'echo -n "{ctx.resource.content}" | {sudo}tee {ctx.resource.path}',
+            result = await resource.host.execute(
+                f'echo -n "{resource.content}" | {sudo}tee {resource.path}',
                 ctx,
             )
             if result.failed():
                 return
 
         if ctx.changes.get("mode") is not None:
-            result = await ctx.resource.host.execute(
-                f"{sudo}chmod {ctx.resource.mode} " f"{ctx.resource.path}",
+            result = await resource.host.execute(
+                f"{sudo}chmod {resource.mode} " f"{resource.path}",
                 ctx,
             )
             if result.failed():
                 return
 
         if ctx.changes.get("owner") is not None:
-            result = await ctx.resource.host.execute(
-                f"{sudo}chown {ctx.resource.owner} {ctx.resource.path}",
+            result = await resource.host.execute(
+                f"{sudo}chown {resource.owner} {resource.path}",
                 ctx,
             )
             if result.failed():
                 return
 
         if ctx.changes.get("group") is not None:
-            result = await ctx.resource.host.execute(
-                f"{sudo}chgrp {ctx.resource.group} {ctx.resource.path}",
+            result = await resource.host.execute(
+                f"{sudo}chgrp {resource.group} {resource.path}",
                 ctx,
             )
             if result.failed():

--- a/eikobot/core/package_manager/__init__.py
+++ b/eikobot/core/package_manager/__init__.py
@@ -18,7 +18,7 @@ from packaging import version
 from pydantic import BaseModel, ValidationError
 
 from ... import VERSION
-from .. import logger
+from .. import human_readable, logger
 from ..compiler.importlib import INTERNAL_LIB_PATH
 from ..errors import EikoError
 
@@ -207,15 +207,6 @@ def _download_pkg(url: str) -> None:
         )
 
 
-def _human_readable(number: int) -> str:
-    number = number // 8
-    for unit in ["", "K", "M", "G", "T"]:
-        if number < 10240:
-            return f"{number}{unit}B"
-        number = number // 1024
-    return f"{number}PB"
-
-
 async def _download_to_cache(url: str) -> None:
     pkg_path = CACHE_PATH / Path(urlparse(url).path).name
     async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(10)) as session:
@@ -234,12 +225,12 @@ async def _download_to_cache(url: str) -> None:
                     if percent == 20:
                         print(
                             f"    [{pg_bar}]",
-                            f"{_human_readable(total_dl_size)}/{_human_readable(total_dl_size)}",
+                            f"{human_readable(total_dl_size)}/{human_readable(total_dl_size)}",
                         )
                     else:
                         print(
                             f"    [{pg_bar}>{(20 - percent - 1) * ' '}]",
-                            f"{_human_readable(downloaded)}/{_human_readable(total_dl_size)}",
+                            f"{human_readable(downloaded)}/{human_readable(total_dl_size)}",
                             end="\r",
                         )
 

--- a/eikobot/core/package_manager/__init__.py
+++ b/eikobot/core/package_manager/__init__.py
@@ -272,6 +272,9 @@ def _install_pkg_from_cache(archive_name: str) -> None:
     if prev_pkg is not None:
         _uninstall_pkg(prev_pkg)
 
+    with tarfile.open(CACHE_PATH / archive_name, "r:gz") as archive:
+        archive.extractall(LIB_PATH)
+
     if pkg_data.version is None:
         logger.debug(f"Installing '{pkg_data.name}'.")
     else:

--- a/eikobot/core/plugin.py
+++ b/eikobot/core/plugin.py
@@ -26,3 +26,13 @@ class EikoPluginException(Exception):
     """
     If something goes wrong inside a plugin, this error should be thrown.
     """
+
+
+@eiko_plugin("type")
+def eiko_type(
+    obj: EikoBaseType,
+) -> str:
+    """
+    Returns the type of a an eiko object as a string.
+    """
+    return obj.type.name

--- a/eikobot/core/plugin.py
+++ b/eikobot/core/plugin.py
@@ -4,6 +4,7 @@ as callables directly to the Eikobot runtime.
 """
 from typing import Callable, Optional, Union
 
+from . import human_readable, machine_readable
 from .compiler.definitions.base_types import EikoBaseType
 
 EikoPluginTyping = Callable[..., Union[None, bool, float, int, str, EikoBaseType]]
@@ -36,3 +37,19 @@ def eiko_type(
     Returns the type of a an eiko object as a string.
     """
     return obj.type.name
+
+
+@eiko_plugin("human_readable")
+def eiko_human_readable(number: int) -> str:
+    """
+    plugin wrapper for core function human_readable
+    """
+    return human_readable(number)
+
+
+@eiko_plugin("machine_readable")
+def eiko_machine_readable(number: str) -> int:
+    """
+    plugin wrapper for core function machine_readable
+    """
+    return machine_readable(number)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ disallow_untyped_decorators = True
 
 [flake8]
 max-line-length = 120
-ignore = W191, W503, F401
+ignore = W191, W503, F401, E203
 exclude =
     __pycache__,
     build,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(this_directory / "README.md", encoding="utf-8") as f:
 
 VERSION = "0.6.0"
 REQUIRES = [
-    "aiohttp==3.8.4",
+    "aiohttp==3.8.5",
     "asyncssh==2.13.1",
     "click==8.1.3",
     "colorama==0.4.6",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ this_directory = Path(__file__).parent
 with open(this_directory / "README.md", encoding="utf-8") as f:
     long_description = f.read()
 
-VERSION = "0.5.1"
+VERSION = "0.6.0"
 REQUIRES = [
     "aiohttp==3.8.4",
     "asyncssh==2.13.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,3 +150,8 @@ def eiko_promises_file() -> Path:
 @pytest.fixture
 def eiko_enum_file() -> Path:
     return get_file("test_enum.eiko")
+
+
+@pytest.fixture
+def eiko_for_file() -> Path:
+    return get_file("test_for.eiko")

--- a/tests/files/test_dict.eiko
+++ b/tests/files/test_dict.eiko
@@ -6,3 +6,7 @@ test_dict: dict[str, Union[str, int, bool]] = {
 
 a = test_dict["key_2"]
 test_dict["key_4"] = True
+
+d = {"key": "value"}
+d.get("key")
+d.get("key", default_value=None)

--- a/tests/files/test_for.eiko
+++ b/tests/files/test_for.eiko
@@ -1,0 +1,13 @@
+import std
+
+haha = "haha"
+test_list: list[Union[str, int]] = []
+
+for obj in ["hello", haha, 12]:
+    test_list.append(obj)
+
+for obj in {"key_1": "test", 1: 1}:
+    test_list.append(obj)
+
+for obj in test_list:
+    std.inspect(obj)

--- a/tests/files/test_inheritance.eiko
+++ b/tests/files/test_inheritance.eiko
@@ -27,3 +27,9 @@ e = Test(a)
 f = Test(b)
 g = Test(c)
 h = Test(d)
+
+
+resource TripleDotInherit(BaseRes):
+    ...
+
+i = TripleDotInherit("a", 1)

--- a/tests/std/test_file.py
+++ b/tests/std/test_file.py
@@ -34,7 +34,7 @@ from std.file import File
 
 File(
     host=Host("127.0.0.1"),
-    path=Path("{file_path}"),
+    path=Path(r"{file_path}"),
     content="{file_content}",
 )
 """
@@ -46,7 +46,8 @@ File(
 
     assert file_path.exists()
     assert file_path.read_text() == file_content
-    assert (oct(os.stat(file_path).st_mode & 0o777))[2:] == "664"
+    if os.name != "nt":
+        assert (oct(os.stat(file_path).st_mode & 0o777))[2:] == "664"
 
     with open(file_path, "w", encoding="utf-8") as f:
         f.write("wrong content")

--- a/tests/std/test_std.py
+++ b/tests/std/test_std.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-function-docstring
 # pylint: disable=protected-access
 # pylint: disable=too-many-statements
+import os
 from pathlib import Path
 
 import pytest
@@ -60,12 +61,23 @@ def test_bad_v6_addr(tmp_eiko_file: Path, param_input: str) -> None:
 @pytest.mark.asyncio
 async def test_cmd_deploy(tmp_eiko_file: Path) -> None:
     file_path = tmp_eiko_file.parent / "test_std_file_deploy"
-    model = f"""
+
+    if os.name != "nt":
+        model = f"""
 from std import Host, Cmd
 
 Cmd(
     Host("127.0.0.1"),
     "touch /{file_path}",
+)
+"""
+    else:
+        model = f"""
+from std import Host, Cmd
+
+Cmd(
+    Host("127.0.0.1"),
+    r"set-content -Path {file_path} -Value $null",
 )
 """
     with open(tmp_eiko_file, "w", encoding="utf-8") as f:

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -10,6 +10,7 @@ from eikobot.core.compiler import Compiler
 from eikobot.core.compiler._parser import Parser
 from eikobot.core.compiler.definitions._resource import EikoResourceDefinition
 from eikobot.core.compiler.definitions.base_types import (
+    EikoBool,
     EikoEnumValue,
     EikoInt,
     EikoNone,
@@ -298,3 +299,25 @@ def test_enum(eiko_enum_file: Path) -> None:
     var_enum_to_str = compiler.context.get("enum_to_str")
     assert isinstance(var_enum_to_str, EikoStr)
     assert var_enum_to_str.value == "option_3"
+
+
+@pytest.mark.parametrize(
+    "input_str,outcome",
+    [
+        ('a = 1\nb = type(a) == "int"', True),
+        ('a = 1\nb = type(a) == "str"', False),
+        ('a = "1"\nb = type(a) == "str"', True),
+        ('a = True\nb = type(a) == "bool"', True),
+        ('a = [True]\nb = type(a) == "list[bool]"', True),
+    ],
+)
+def test_type_plugin(tmp_eiko_file: Path, input_str: str, outcome: bool) -> None:
+    compiler = Compiler()
+
+    with open(tmp_eiko_file, "w", encoding="utf-8") as f:
+        f.write(input_str)
+
+    compiler.compile(tmp_eiko_file)
+    b = compiler.context.get("b")
+    assert isinstance(b, EikoBool)
+    assert b.value == outcome

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -13,6 +13,7 @@ from eikobot.core.compiler.definitions.base_types import (
     EikoBool,
     EikoEnumValue,
     EikoInt,
+    EikoList,
     EikoNone,
     EikoResource,
     EikoStr,
@@ -321,3 +322,26 @@ def test_type_plugin(tmp_eiko_file: Path, input_str: str, outcome: bool) -> None
     b = compiler.context.get("b")
     assert isinstance(b, EikoBool)
     assert b.value == outcome
+
+
+def test_for(eiko_for_file: Path) -> None:
+    compiler = Compiler()
+    compiler.compile(eiko_for_file)
+
+    results_list = compiler.context.get("test_list")
+    assert isinstance(results_list, EikoList)
+
+    assert isinstance(results_list.elements[0], EikoStr)
+    assert results_list.elements[0].value == "hello"
+
+    assert isinstance(results_list.elements[1], EikoStr)
+    assert results_list.elements[1].value == "haha"
+
+    assert isinstance(results_list.elements[2], EikoInt)
+    assert results_list.elements[2].value == 12
+
+    assert isinstance(results_list.elements[3], EikoStr)
+    assert results_list.elements[3].value == "key_1"
+
+    assert isinstance(results_list.elements[4], EikoInt)
+    assert results_list.elements[4].value == 1

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -268,6 +268,14 @@ def test_inheritance(eiko_inheritance_file: Path) -> None:
         "prop_1": var_d.to_py(),
     }
 
+    var_i = compiler.context.get("i")
+    assert isinstance(var_i, EikoResource)
+    assert var_i.type.name == "TripleDotInherit"
+    assert var_i.to_py() == {
+        "prop_1": "a",
+        "prop_2": 1,
+    }
+
 
 def test_enum(eiko_enum_file: Path) -> None:
     compiler = Compiler()

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -4,8 +4,10 @@
 # pylint: disable=too-many-statements
 from pathlib import Path
 
+import pytest
+
 from eikobot.core.compiler._token import Token, TokenType
-from eikobot.core.compiler.lexer import Lexer
+from eikobot.core.compiler.lexer import EikoSyntaxError, Lexer
 from eikobot.core.compiler.misc import Index
 
 
@@ -455,3 +457,19 @@ def test_comment_end_of_file_lexing(tmp_eiko_file: Path) -> None:
     lexer = Lexer(tmp_eiko_file)
     assert lexer.next_token() == Token(TokenType.INDENT, "", Index(0, 0, tmp_eiko_file))
     assert lexer.next_token() == Token(TokenType.EOF, "EOF", Index(1, 0, tmp_eiko_file))
+
+
+def test_unicode_escape_error(tmp_eiko_file: Path) -> None:
+    file_path = "\\U"
+    model = f'path = Path("{file_path}")'
+    with open(tmp_eiko_file, "w", encoding="utf-8") as f:
+        f.write(model)
+
+    lexer = Lexer(tmp_eiko_file)
+    lexer.next_token()
+    lexer.next_token()
+    lexer.next_token()
+    lexer.next_token()
+    lexer.next_token()
+    with pytest.raises(EikoSyntaxError):
+        lexer.next_token()


### PR DESCRIPTION
# 0.6.0

- Much better support for windows hosts!
- Added `HostModel.scp_to` and `HostModel.scp_from` to copy files with SCP
- Fixed a bug where `.` wasn't parsed properly in the inheritance declaration
- Fixed a bug where promises were not properly inherited
- Implemented `...`, a statement that allows for inheriting without new properties being added
- Allow inheritance to only overwrite the constructor, with no additional properties
- Fixed a bug where lists and dicts as default arguments caused a compilation issue
- Fixed a bug in the comparison operations where `None` would not equal itself
- Fixed a bug where a hanging comma in a constructor arg list would cause a syntax error
- Made TaskID accessible through `HandlerContext`
- Added Task cache (This is a directory unique to the current Task/Handler and can be used to save files)
- Fixed several bugs in the type system
- Add a 🤖 to some of the logs
- Fixed a bug in the package manager that occurred when installing an already installed package
- Add a plugin `type` that returns the typing of an object as a string
- Made all the tests windows compatible
- If host verification fails due to missing keys, we allow the user to add those key
- Add `for` loops that loop over iterables (currently just lists and dicts)
- Implement `dict.get` function, that can retrieve a value with a default value